### PR TITLE
Elasticsearch Default Config

### DIFF
--- a/agamemnon/elasticsearch.py
+++ b/agamemnon/elasticsearch.py
@@ -19,8 +19,8 @@ class FullTextSearch(object):
                     'analysis' : {
                         'analyzer' : {                             
                             'ngram_analyzer' : {                   
-                                'tokenizer' : 'standard',
-                                'filter' : ['standard', 'filter_ngram'],
+                                'tokenizer' : 'keyword',
+                                'filter' : ['lowercase', 'filter_ngram'],
                                 'type' : 'custom'
                             }  
                         },
@@ -55,7 +55,9 @@ class FullTextSearch(object):
                             'analyzer' : 'ngram_analyzer',
                             'type': u'string',
                             'term_vector': 'with_positions_offsets'}
-        index_settings = {'index_analyzer':'ngram_analyzer','search_analyzer':'standard','properties':mapping}
+        index_settings = {'index_analyzer':'ngram_analyzer',
+                          'search_analyzer':'standard',
+                          'properties':mapping}
         self.conn.put_mapping(str(type),index_settings,[ns_index_name])
         self.refresh_index_cache()
         self.populate_index(type, index_name)

--- a/agamemnon/factory.py
+++ b/agamemnon/factory.py
@@ -14,7 +14,6 @@ from agamemnon.memory import InMemoryDataStore
 from agamemnon.exceptions import NodeNotFoundException, PluginDisabled
 import agamemnon.primitives as prim
 from agamemnon.delegate import Delegate
-from agamemnon.elasticsearch import FullTextSearch
 import logging
 
 log = logging.getLogger(__name__)
@@ -526,6 +525,7 @@ def load_from_settings(settings, prefix='agamemnon.'):
     plugin_dict = {}
     try:
         if(settings['es_server']!='disable'):
+            from agamemnon.elasticsearch import FullTextSearch
             plugin_dict['elastic_search'] = FullTextSearch(settings['es_server'],settings['es_config'])
     except KeyError:
         pass
@@ -533,10 +533,9 @@ def load_from_settings(settings, prefix='agamemnon.'):
     if settings["%skeyspace" % prefix] == 'memory':
         delegate = InMemoryDataStore()
     else:
-        delegate = CassandraDataStore(settings['%skeyspace' % prefix],
-            pycassa.pool.ConnectionPool(settings["%skeyspace" % prefix],
-                json.loads(settings["%shost_list" % prefix])),
-                system_manager=pycassa.system_manager.SystemManager(
-                json.loads(settings["%shost_list" % prefix])[0]))
+        delegate = CassandraDataStore(
+            settings['%skeyspace' % prefix],
+            pycassa.pool.ConnectionPool(settings["%skeyspace" % prefix],json.loads(settings["%shost_list" % prefix])),
+            system_manager=pycassa.system_manager.SystemManager(json.loads(settings["%shost_list" % prefix])[0]))
     delegate.load_plugins(plugin_dict)
     return DataStore(delegate)

--- a/agamemnon/factory.py
+++ b/agamemnon/factory.py
@@ -534,7 +534,7 @@ def load_from_settings(settings, prefix='agamemnon.'):
         delegate = InMemoryDataStore()
     else:
         delegate = CassandraDataStore(settings['%skeyspace' % prefix],
-            pycassa.connect(settings["%skeyspace" % prefix],
+            pycassa.pool.ConnectionPool(settings["%skeyspace" % prefix],
                 json.loads(settings["%shost_list" % prefix])),
                 system_manager=pycassa.system_manager.SystemManager(
                 json.loads(settings["%shost_list" % prefix])[0]))

--- a/agamemnon/tests/unit_tests.py
+++ b/agamemnon/tests/unit_tests.py
@@ -335,7 +335,7 @@ class CassandraTests(TestCase, AgamemnonTests):
     def setUp(self):
         host_list = '["localhost:9160"]'
         keyspace = 'agamemnontests'
-        es_server = '33.33.33.10:9200'
+        es_server = 'disable'
         try:
             cassandra.drop_keyspace(host_list, keyspace)
         except Exception:
@@ -350,7 +350,7 @@ class CassandraTests(TestCase, AgamemnonTests):
 
 class InMemoryTests(TestCase, AgamemnonTests):
     def setUp(self):
-        self.ds = load_from_settings({'agamemnon.keyspace': 'memory','es_server':'33.33.33.10:9200','es_config':''})
+        self.ds = load_from_settings({'agamemnon.keyspace': 'memory','es_server':'disable','es_config':''})
 
 class ElasticSearchTests(TestCase, AgamemnonTests):
     def setUp(self):


### PR DESCRIPTION
Elasticsearch is now by default case insensitive.
